### PR TITLE
Add space so that inputs don't overlap

### DIFF
--- a/beta.html
+++ b/beta.html
@@ -64,7 +64,7 @@
             display: inline;
 
             float: left;
-            width: 16em;
+            width: 18em;
             height: 1.6em;
             text-decoration: none;
             padding: 0.2em 0.6em;


### PR DESCRIPTION
Add Space to list box descriptions so that the input boxes don't overlap each other.

The screenshots below are on Chrome 85.0.4183.83, on windows 10.

### Before, mobile
![Before - Mobile](https://user-images.githubusercontent.com/386023/92334278-121b8780-f052-11ea-8810-838e56b3bd4b.png)
### After, Mobile
![After - Mobile](https://user-images.githubusercontent.com/386023/92334283-1a73c280-f052-11ea-99b2-3f8714631629.png)
### Before, Computer
![Before - Computer](https://user-images.githubusercontent.com/386023/92334289-1e074980-f052-11ea-96bc-56e529f63fd4.png)
### After, Computer
![After - Computer](https://user-images.githubusercontent.com/386023/92334293-2495c100-f052-11ea-9202-09935b9b4f14.png)
